### PR TITLE
use functional style for `getDays`

### DIFF
--- a/lib/src/week.js
+++ b/lib/src/week.js
@@ -2,6 +2,7 @@
  * A week consisting of named days (Monday - Sunday).
  */
 function Week() {
+    var self = this;
 
     this.monday = undefined;
     this.tuesday = undefined;
@@ -35,29 +36,12 @@ function Week() {
      * A day is only added to the array if it is defined.
      */
     this.getDays = function() {
-        var days = [];
-        if (typeof this.monday !== "undefined") {
-            days.push(this.monday);
-        }
-        if (typeof this.tuesday !== "undefined") {
-            days.push(this.tuesday);
-        }
-        if (typeof this.wednesday !== "undefined") {
-            days.push(this.wednesday);
-        }
-        if (typeof this.thursday !== "undefined") {
-            days.push(this.thursday);
-        }
-        if (typeof this.friday !== "undefined") {
-            days.push(this.friday);
-        }
-        if (typeof this.saturday !== "undefined") {
-            days.push(this.saturday);
-        }
-        if (typeof this.sunday !== "undefined") {
-            days.push(this.sunday);
-        }
-        return days;
+        return self.FIELD_NAMES_ENGLISH
+            .filter(function(dayName) {
+                return typeof self[dayName] !== "undefined";
+            }).map(function(dayName) {
+                return self[dayName];
+            });
     };
 
     this.getUpdatedDay = function(day, specificDay) {


### PR DESCRIPTION
I just could not bear not having this improvement in the code. The trick is to use the `self = this` at the top to keep the reference even in the inherited function. With this change the code still works. What do you think @johnjohndoe ?